### PR TITLE
Hide legacy archive months

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -4,7 +4,7 @@ if (is_child_theme()) {
     // Hide old archive months (2008-2016)
     wp_enqueue_script(
         'hide-old-archive-months',
-        get_template_directory_uri() . 'js/hide-old-archive-months.js',
+        get_stylesheet_directory_uri() . '/js/hide-old-archive-months.js',
         ['jquery'],
         false,
         true

--- a/functions.php
+++ b/functions.php
@@ -1,2 +1,12 @@
 <?php
-//* Code goes here
+
+if (is_child_theme()) {
+    // Hide old archive months (2008-2016)
+    wp_enqueue_script(
+        'hide-old-archive-months',
+        get_template_directory_uri() . 'js/hide-old-archive-months.js',
+        ['jquery'],
+        false,
+        true
+    );
+}

--- a/js/hide-old-archive-months.js
+++ b/js/hide-old-archive-months.js
@@ -1,0 +1,15 @@
+(function($) {
+    // Default the pre-2017 dates to hidden
+     $('aside.widget_archive > ul > li').each(function(i, element) {
+        if (/(.*) 2(008|009|010|011|012|013)$/.test($(element).text())){
+            $(element).hide();
+        }
+    });
+    // Append a 'show all' link
+    var showAll = $('<div class="text-right"><button class="btn-sm btn-secondary">Show All</button></div>');
+    $('button', showAll).on('click', function() {
+        $('aside.widget_archive > ul > li').show();
+        $(this).hide();
+    });
+    $('aside.widget_archive').append(showAll);
+})(jQuery);


### PR DESCRIPTION
<img width="376" alt="screen shot 2017-07-13 at 10 43 52 am" src="https://user-images.githubusercontent.com/80459/28174849-40f0b862-67b8-11e7-88c6-55bb6f1220bc.png">

Sidebar is getting too long, so this makes it slightly more usable by hiding anything older than the re-launch.